### PR TITLE
Export the useViewport hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export { useViewport } from "@/lib/viewport";
 export * from "@/components";


### PR DESCRIPTION
This commit to allow the usage of useViewport hook from external project. 

This aims to allow pdf viewer behaviour from something else than human action on pdfreader control components, so by a programmatic action.

My use case is related to a more complex web app where I should display a specific PDF page when the end user do a specific action on components that are outside of the pdfreader.

Of course, this means the hook must stay in the component tree of the root component.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Export `useViewport` in `src/index.ts` for external usage to enable programmatic PDF viewer control.
> 
>   - **Exports**:
>     - Export `useViewport` from `src/index.ts` to allow external projects to use the hook.
>   - **Purpose**:
>     - Enables programmatic control of PDF viewer behavior from outside the PDF reader components.
>     - Supports complex web apps needing to display specific PDF pages based on external actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=OnedocLabs%2Fpdfreader&utm_source=github&utm_medium=referral)<sup> for 82bb535127bac28d4c0f3208885bc90e37d0c8bd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->