### PR TITLE
Export additional API for public consumption

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,13 @@
+// @NOTE
+// - Required for custom `AnnotationLayer`
+export { usePDFPage } from "@/lib/pdf/page";
+export { useVisibility } from "@/lib/viewport";
+export { usePDFLinkService } from "@/lib/pdf/links";
+
+// @NOTE
+// - Required for `Viewer`
+export { usePDFDocument } from "@/lib/pdf/document";
+
+// @NOTE
+// - Defaults
 export * from "@/components";


### PR DESCRIPTION
### Overview

- Exposes internal API's required for custom `AnnotationLayer`
- Exposes `usePDFDocument` as per https://github.com/OnedocLabs/pdfreader/issues/4

### Notes

- Once validated will add docs to Storybook and PR back upstream.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expose additional internal APIs in `src/index.ts` for custom `AnnotationLayer` and `Viewer`.
> 
>   - **Exports**:
>     - `usePDFPage` from `@/lib/pdf/page` for custom `AnnotationLayer`.
>     - `useVisibility` from `@/lib/viewport` for custom `AnnotationLayer`.
>     - `usePDFLinkService` from `@/lib/pdf/links` for custom `AnnotationLayer`.
>     - `usePDFDocument` from `@/lib/pdf/document` for `Viewer`.
>   - **Context**:
>     - Addresses GitHub issue for exposing `usePDFDocument`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=OnedocLabs%2Fpdfreader&utm_source=github&utm_medium=referral)<sup> for a0fabab42f7a3236e76fee0ffd72009507f0f215. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->