### PR TITLE
Viewport provider refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "clsx": "^2.1.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
-        "pdfjs-dist": "^4.4.168",
         "playwright": "^1.45.3",
         "prettier": "^3.3.2",
         "react": "^18.3.1",
@@ -3822,9 +3821,9 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
       "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -3844,9 +3843,9 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7088,9 +7087,9 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true,
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -7156,9 +7155,9 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -7231,7 +7230,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7298,9 +7297,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "dev": true,
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/archiver": {
       "version": "7.0.1",
@@ -7523,9 +7522,9 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
       "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -7866,7 +7865,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -8022,7 +8021,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8289,10 +8288,10 @@
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
       "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.17.0",
@@ -8401,7 +8400,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -8675,9 +8674,9 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -8775,7 +8774,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -8799,9 +8798,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true,
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -9126,7 +9125,7 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
       "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -9154,9 +9153,9 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "mimic-response": "^2.0.0"
       },
@@ -9326,9 +9325,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -9375,9 +9374,9 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9666,7 +9665,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -10914,7 +10913,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -10927,7 +10926,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -10940,14 +10939,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -10980,9 +10979,9 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
       "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
@@ -11002,9 +11001,9 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -11280,7 +11279,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -11586,9 +11585,9 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true,
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/hasha": {
       "version": "5.2.2",
@@ -11796,9 +11795,9 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -11942,7 +11941,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -11953,7 +11952,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -12080,7 +12079,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15071,7 +15070,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -15231,9 +15230,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -15255,7 +15254,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -15278,7 +15277,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -15288,7 +15287,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -15302,7 +15301,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -15315,7 +15314,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/mitt": {
@@ -15329,7 +15328,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -15385,7 +15384,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/msw": {
@@ -15536,9 +15535,9 @@
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
       "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
-      "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -15630,7 +15629,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -15685,9 +15684,9 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -15739,9 +15738,9 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
       "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
@@ -16118,7 +16117,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16161,7 +16160,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -16535,7 +16534,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16606,9 +16605,9 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.1.tgz",
       "integrity": "sha512-Fl2z/BHvkTNvkuBzYTpTuirHZg6wW9z8+4SND/3mDTEcYbbNKWAy21dz9D3ePNNwrrK8pqZO5vLPZ1hLF6T7XA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -16634,8 +16633,8 @@
       "version": "4.4.168",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.4.168.tgz",
       "integrity": "sha512-MbkAjpwka/dMHaCfQ75RY1FXX3IewBVu6NGZOcxerRFlaBiIkZmUoR0jotX5VUzYZEXAGzSFtknWs5xRKliXPA==",
-      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -17551,7 +17550,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -17956,7 +17955,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -18056,7 +18055,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -18094,7 +18093,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -18185,7 +18184,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/set-function-length": {
@@ -18286,14 +18285,13 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18309,15 +18307,16 @@
         }
       ],
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/simple-get": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
       "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
@@ -18725,7 +18724,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -18762,7 +18761,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -18806,7 +18805,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -18937,7 +18936,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
       "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -18979,7 +18978,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/telejson": {
@@ -19225,7 +19224,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tree-kill": {
@@ -19723,7 +19722,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -20402,7 +20401,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack-sources": {
@@ -20426,7 +20425,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -20497,9 +20496,9 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
@@ -20611,7 +20610,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "test": "test-storybook",
     "build": "vite build && tsc --emitDeclarationOnly --declaration && tsc-alias",
+    "prepare": "npm run build",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test:browser": "vitest --workspace=vitest.workspace.ts"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@vitest/browser": "^2.0.4",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "pdfjs-dist": "^4.4.168",
     "playwright": "^1.45.3",
     "prettier": "^3.3.2",
     "react": "^18.3.1",

--- a/src/components/Layers/index.tsx
+++ b/src/components/Layers/index.tsx
@@ -8,6 +8,10 @@ import { usePDFPage } from "@/lib/pdf/page";
 import clsx from "clsx";
 import { HTMLProps } from "react";
 
+type CanvasLayerProps = HTMLProps<HTMLCanvasElement> & {
+  zoom?: number;
+}
+
 export const TextLayer = ({
   className,
   style,
@@ -58,10 +62,11 @@ export const AnnotationLayer = ({
 };
 
 export const CanvasLayer = ({
+  zoom = 1,
   style,
   ...props
-}: HTMLProps<HTMLCanvasElement>) => {
-  const { canvasRef } = useCanvasLayer();
+}: CanvasLayerProps) => {
+  const { canvasRef } = useCanvasLayer({ zoom });
 
   return (
     <canvas

--- a/src/components/Layers/index.tsx
+++ b/src/components/Layers/index.tsx
@@ -32,12 +32,14 @@ export const TextLayer = ({
 
 export const AnnotationLayer = ({
   renderForms = true,
+  annotations,
   className,
   style,
   ...props
 }: AnnotationLayerParams & HTMLProps<HTMLDivElement>) => {
   const { annotationLayerRef } = useAnnotationLayer({
     renderForms,
+    annotations,
   });
 
   return (

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -7,7 +7,7 @@ import {
   useCreatePDFLinkService,
   PDFLinkServiceContext,
 } from "@/lib/pdf/links";
-import { useViewportContext, ViewportContext } from "@/lib/viewport";
+import { useViewportContext } from "@/lib/viewport";
 import { forwardRef, HTMLProps, ReactNode } from "react";
 import { Primitive } from "../Primitive";
 
@@ -37,11 +37,9 @@ export const Root = forwardRef(
       <Primitive.div ref={ref} {...props}>
         {ready ? (
           <PDFDocumentContext.Provider value={context}>
-            <ViewportContext.Provider value={viewportContext}>
-              <PDFLinkServiceContext.Provider value={linkService}>
-                {children}
-              </PDFLinkServiceContext.Provider>
-            </ViewportContext.Provider>
+            <PDFLinkServiceContext.Provider value={linkService}>
+              {children}
+            </PDFLinkServiceContext.Provider>
           </PDFDocumentContext.Provider>
         ) : (
           loader || "Loading..."

--- a/src/components/Viewport/index.tsx
+++ b/src/components/Viewport/index.tsx
@@ -1,6 +1,15 @@
-import { useViewportContainer } from "@/lib/viewport";
-import { HTMLProps, useRef } from "react";
 import { Primitive } from "../Primitive";
+import { type HTMLProps, type ReactNode, useRef } from "react";
+import { useViewportContainer, useViewportContext, ViewportContext } from "@/lib/viewport";
+
+export const ViewportProvider = ({ children }: { children: ReactNode }) => {
+  const viewportContext = useViewportContext({});
+  return (
+    <ViewportContext.Provider value={viewportContext}>
+      {children}
+    </ViewportContext.Provider>
+  )
+}
 
 export const Viewport = ({ children, ...props }: HTMLProps<HTMLDivElement>) => {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,5 +1,5 @@
 import "pdfjs-dist/web/pdf_viewer.css";
-import { Viewport } from "./Viewport";
+import { Viewport, ViewportProvider } from "./Viewport";
 import { useViewport } from "@/lib/viewport";
 import { Root } from "./Root";
 import { Page } from "./Page";
@@ -66,6 +66,7 @@ export {
   useViewport,
   // Components
   Viewport,
+  ViewportProvider,
   Root,
   Page,
   AnnotationLayer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,13 @@
+// @NOTE
+// - Required for custom `AnnotationLayer`
+export { usePDFPage } from "@/lib/pdf/page";
+export { useVisibility } from "@/lib/viewport";
+export { usePDFLinkService } from "@/lib/pdf/links";
+
+// @NOTE
+// - Required for `Viewer`
+export { usePDFDocument } from "@/lib/pdf/document";
+
+// @NOTE
+// - Defaults
 export * from "@/components";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,6 @@
 // @NOTE
-// - Required for custom `AnnotationLayer`
-export { usePDFPage } from "@/lib/pdf/page";
-export { useVisibility } from "@/lib/viewport";
-export { usePDFLinkService } from "@/lib/pdf/links";
-
-// @NOTE
 // - Required for `Viewer`
+export { useViewport } from "@/lib/viewport";
 export { usePDFDocument } from "@/lib/pdf/document";
 
 // @NOTE

--- a/src/lib/pdf/document.ts
+++ b/src/lib/pdf/document.ts
@@ -50,6 +50,9 @@ export const usePDFDocumentContext = ({ fileURL }: usePDFDocumentParams) => {
         setReady(true);
       },
       (error) => {
+        // @NOTE
+        // - https://github.com/wojtekmaj/react-pdf/discussions/1212
+        if (loadingTask.destroyed) return;
         // eslint-disable-next-line no-console
         console.error("Error loading PDF document", error);
       },

--- a/src/lib/pdf/document.ts
+++ b/src/lib/pdf/document.ts
@@ -1,11 +1,8 @@
 import {
   getDocument,
-  GlobalWorkerOptions,
   OnProgressParameters,
   PDFDocumentProxy,
 } from "pdfjs-dist";
-// @ts-expect-error Vite Worker
-import PDFWorker from "pdfjs-dist/build/pdf.worker.min.mjs?url&inline";
 import { RefProxy } from "pdfjs-dist/types/src/display/api";
 import {
   createContext,
@@ -15,12 +12,6 @@ import {
   useRef,
   useState,
 } from "react";
-
-/**
- * General setup for pdf.js
- */
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-GlobalWorkerOptions.workerSrc = PDFWorker;
 
 /**
  * Load a document

--- a/src/lib/pdf/layers/annotation.ts
+++ b/src/lib/pdf/layers/annotation.ts
@@ -8,15 +8,13 @@ import { usePDFPage } from "../page";
 import { cancellable } from "../utils";
 
 export interface AnnotationLayerParams {
-  /**
-   * Whether to render forms.
-   */
   renderForms?: boolean;
+  annotations?: any[];
 }
 
 const defaultAnnotationLayerParams = {
   renderForms: true,
-} satisfies Required<AnnotationLayerParams>;
+};
 
 export const useAnnotationLayer = (params: AnnotationLayerParams) => {
   const annotationLayerRef = useRef<HTMLDivElement>(null);
@@ -66,7 +64,7 @@ export const useAnnotationLayer = (params: AnnotationLayerParams) => {
           ...annotationLayerConfig,
           ...defaultAnnotationLayerParams,
           ...params,
-          annotations: await pdfPageProxy.getAnnotations(),
+          annotations: params.annotations ?? await pdfPageProxy.getAnnotations(),
           // @ts-expect-error TODO: Fix this
           linkService,
         });

--- a/src/lib/pdf/layers/canvas.ts
+++ b/src/lib/pdf/layers/canvas.ts
@@ -1,17 +1,20 @@
 import { useDebounce } from "@uidotdev/usehooks";
 import { useEffect, useRef } from "react";
 
-import { useDPR, useViewport } from "@/lib/viewport";
+import { useDPR } from "@/lib/viewport";
 
 import { usePDFPage } from "../page";
 import { AnnotationMode } from "pdfjs-dist";
 
-export const useCanvasLayer = () => {
+type UseCanvasLayerParams = {
+  zoom: number;
+}
+
+export const useCanvasLayer = ({ zoom: scale }: UseCanvasLayerParams) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { pdfPageProxy } = usePDFPage();
   const dpr = useDPR();
-  const { zoom: bouncyZoom } = useViewport();
-  const zoom = useDebounce(bouncyZoom, 100);
+  const zoom = useDebounce(scale, 100);
 
   useEffect(() => {
     if (!canvasRef.current) {

--- a/src/lib/pdf/layers/canvas.ts
+++ b/src/lib/pdf/layers/canvas.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { useDPR, useViewport, useVisibility } from "@/lib/viewport";
 
 import { usePDFPage } from "../page";
+import { AnnotationMode } from "pdfjs-dist";
 
 export const useCanvasLayer = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -35,6 +36,9 @@ export const useCanvasLayer = () => {
     canvasContext.scale(scale, scale);
 
     const renderingTask = pdfPageProxy.render({
+      // @TODO
+      // - Could pass this through at the Context level (Root) as prop
+      annotationMode: AnnotationMode.DISABLE,
       canvasContext: canvasContext,
       viewport,
     });

--- a/src/lib/pdf/layers/canvas.ts
+++ b/src/lib/pdf/layers/canvas.ts
@@ -1,7 +1,7 @@
 import { useDebounce } from "@uidotdev/usehooks";
 import { useEffect, useRef } from "react";
 
-import { useDPR, useViewport, useVisibility } from "@/lib/viewport";
+import { useDPR, useViewport } from "@/lib/viewport";
 
 import { usePDFPage } from "../page";
 import { AnnotationMode } from "pdfjs-dist";
@@ -10,10 +10,8 @@ export const useCanvasLayer = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { pdfPageProxy } = usePDFPage();
   const dpr = useDPR();
-  const { visible } = useVisibility({ elementRef: canvasRef });
   const { zoom: bouncyZoom } = useViewport();
   const zoom = useDebounce(bouncyZoom, 100);
-  const debouncedVisible = useDebounce(visible, 100);
 
   useEffect(() => {
     if (!canvasRef.current) {
@@ -24,7 +22,7 @@ export const useCanvasLayer = () => {
 
     const canvas = canvasRef.current;
 
-    const scale = debouncedVisible ? dpr * zoom : 0.5;
+    const scale = dpr * zoom;
 
     canvas.height = viewport.height * scale;
     canvas.width = viewport.width * scale;
@@ -55,7 +53,7 @@ export const useCanvasLayer = () => {
     return () => {
       void renderingTask.cancel();
     };
-  }, [pdfPageProxy, canvasRef.current, dpr, debouncedVisible, zoom]);
+  }, [pdfPageProxy, canvasRef.current, dpr, zoom]);
 
   return {
     canvasRef,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     emptyOutDir: true,
     sourcemap: true,
     rollupOptions: {
-      external: ["react"],
+      external: ["react", "pdfjs-dist", "pdfjs-dist/build/pdf.worker.entry"]
     },
   },
   plugins: [react()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
     emptyOutDir: true,
     sourcemap: true,
     rollupOptions: {
-      external: ["react", "pdfjs-dist", "pdfjs-dist/build/pdf.worker.entry"]
+      external: [
+        "react",
+        "pdfjs-dist",
+      ]
     },
   },
   plugins: [react()],


### PR DESCRIPTION
### Overview

- Removes the need for the viewport component and instead passes `zoom` directly to the `CanvasLayer`

### To Do

- Undo changes made in https://github.com/feytools/pdfreader/pull/5 & https://github.com/feytools/pdfreader/pull/6
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor viewport handling by removing `ViewportContext` and directly passing `zoom` to `CanvasLayer`, and update build scripts.
> 
>   - **Behavior**:
>     - Removes `ViewportContext` from `Root` in `index.tsx` and directly passes `zoom` to `CanvasLayer` in `Layers/index.tsx`.
>     - Adds `ViewportProvider` in `Viewport/index.tsx` but does not use it in `Root`.
>     - Removes `GlobalWorkerOptions` setup in `document.ts`.
>   - **Build**:
>     - Adds `prepare` script in `package.json` to run `npm run build`.
>     - Removes `pdfjs-dist` from `devDependencies` in `package.json`.
>   - **Misc**:
>     - Updates `vite.config.ts` to include `pdfjs-dist` as external in `rollupOptions`.
>     - Adds `annotations` prop to `AnnotationLayer` in `Layers/index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=OnedocLabs%2Fpdfreader&utm_source=github&utm_medium=referral)<sup> for 922c428751692f8131a78671bcb39a532d6c7bf3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->